### PR TITLE
updated to mio 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ license = "MIT"
 travis-ci = { repository = "oefd/mio-timerfd", branch = "master" }
 
 [dependencies]
-mio = { version = "0.7", features = ["os-util", "os-poll"] }
+mio = { version = "0.8", features = ["os-ext", "os-poll"] }
 libc = "0.2"


### PR DESCRIPTION
All tests pass on x86_64-unknown-linux-gnu.

I forked @sidit77 's repository so I can bump the version number if requested. No other changes have been made.