### PR TITLE
Adapt to mio v0.8.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "mio-timerfd"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Terry Kerr <terry@oefd.ca>"]
-edition = "2018"
+edition = "2021"
 description = "mio support for linux's timerfd"
 repository = "https://github.com/oefd/mio-timerfd"
 documentation = "https://docs.rs/mio-timerfd"
@@ -14,5 +14,5 @@ license = "MIT"
 travis-ci = { repository = "oefd/mio-timerfd", branch = "master" }
 
 [dependencies]
-mio = { version = "0.7", features = ["os-util", "os-poll"] }
+mio = { version = "0.8.6", features = ["os-ext", "os-poll"] }
 libc = "0.2"


### PR DESCRIPTION
Fix build isse where Source trait was not found.
 - bump mio version to 0.8.6
 - change feature dependency to os-ext instead of os-util
 - bump rust edition to 2021