### PR TITLE
Support mio version 0.8.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ license = "MIT"
 travis-ci = { repository = "oefd/mio-timerfd", branch = "master" }
 
 [dependencies]
-mio = { version = "0.7", features = ["os-util", "os-poll"] }
+mio = { version = "0.8", features = ["os-ext", "os-poll"] }
 libc = "0.2"


### PR DESCRIPTION
This (very nice) crate seems to work just fine with mio 0.8.x, despite being a few years old.